### PR TITLE
manifest: add EXTRA_PATH to executable script to allow passing a custom path

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.json
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.json
@@ -84,7 +84,7 @@
             "export JAVA_TOOL_OPTIONS",
             "TMPDIR=${XDG_CACHE_HOME}/tmp/",
             "export TMPDIR",
-            "exec env /app/extra/idea-IU/bin/idea.sh \"$@\""
+            "exec env 'PATH=$PATH:$EXTRA_PATH' /app/extra/idea-IU/bin/idea.sh \"$@\""
           ],
           "dest-filename": "idea.sh"
         }


### PR DESCRIPTION
It seems that the flatpak CLI does not allow to pass a certain PATH when
running a flatpak.  In some cases, the user might want to do that,
still, on their own risk. This modification allows the user to pass an
EXTRA_PATH variable which will then get appended to the PATH for calling
the IDE. This allows to run executables from the host.
Of course, that will eventually break. But then it is the user who
actively opted into that breaking behaviour by passing the variable.