### PR TITLE
manifest: reorder EXTRA_PATH so that it is appended to PATH

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.json
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.json
@@ -84,7 +84,7 @@
             "export JAVA_TOOL_OPTIONS",
             "TMPDIR=${XDG_CACHE_HOME}/tmp/",
             "export TMPDIR",
-            "exec env \"PATH=${EXTRA_PATH}:${PATH}\" /app/extra/idea-IU/bin/idea.sh \"$@\""
+            "exec env \"PATH=${PATH}:${EXTRA_PATH}\" /app/extra/idea-IU/bin/idea.sh \"$@\""
           ],
           "dest-filename": "idea.sh"
         }


### PR DESCRIPTION
This should fix a few issues when running stuff in the sandbox, because
preference will be given to the apps bundled with the flatpak rather
than preferring all the apps on the host.