### PR TITLE
intellij idea ultimate edition release 2019.2.1

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.appdata.xml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.appdata.xml
@@ -36,6 +36,7 @@
   <update_contact>idea@jetbrains.com</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release type="stable" date="2019-08-21" version="2019.2.1" />
     <release type="stable" date="2019-07-24" version="2019.2.0" />
     <release type="stable" date="2019-05-28" version="2019.1.3" />
     <release type="stable" date="2019-05-08" version="2019.1.2" />

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.json
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.json
@@ -56,9 +56,9 @@
           "type": "extra-data",
           "filename": "ideaIU.tar.gz",
           "only-arches": ["x86_64"],
-          "sha256": "80b3e740d156021f1d91bb69a1bcb85f3f4b7b73889e5ec614063a216f69436c",
-          "size": 774429686,
-          "url": "https://download.jetbrains.com/idea/ideaIU-2019.2.tar.gz"
+          "sha256": "420cfe9c9c3e49d52c2a5c68385338450f32adc51e91301566fede49732cbf5f",
+          "size": 837562885,
+          "url": "https://download.jetbrains.com/idea/ideaIU-2019.2.1.tar.gz"
         }, {
           "type": "file",
           "path": "com.jetbrains.IntelliJ-IDEA-Ultimate.appdata.xml"


### PR DESCRIPTION
```shell
==> JetBrains IntelliJ IDEA (Ultimate Edition)
Date: 2019-08-21
Version: 2019.2.1
Link: https://download.jetbrains.com/idea/ideaIU-2019.2.1.tar.gz
Size: 837562885
Checksum: 420cfe9c9c3e49d52c2a5c68385338450f32adc51e91301566fede49732cbf5f
Upgrade needed – expected: 2019.2, actual: 2019.2.1
```