### PR TITLE
Add support for external data checker

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.json
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.json
@@ -49,13 +49,6 @@
       ],
       "sources": [
         {
-          "type": "extra-data",
-          "filename": "ideaIU.tar.gz",
-          "only-arches": ["x86_64"],
-          "sha256": "739b1eeb14587fa3fa7c3ceb14293c2773fbe355d12af977aee3a8803beab34b",
-          "size": 795790818,
-          "url": "https://download.jetbrains.com/idea/ideaIU-2019.3.tar.gz"
-        }, {
           "type": "file",
           "sha256": "d43ed7b21751e3950fd70ef02e252544f2a13194f7ea019543ac0d547487fc3a",
           "url": "https://resources.jetbrains.com/storage/products/intellij-idea/docs/intellij-idea_logos.zip"
@@ -71,6 +64,17 @@
         }, {
           "type": "file",
           "path": "com.jetbrains.IntelliJ-IDEA-Ultimate.desktop"
+        }, {
+          "type": "extra-data",
+          "filename": "ideaIU.tar.gz",
+          "only-arches": ["x86_64"],
+          "sha256": "739b1eeb14587fa3fa7c3ceb14293c2773fbe355d12af977aee3a8803beab34b",
+          "size": 795790818,
+          "url": "https://download.jetbrains.com/idea/ideaIU-2019.3.tar.gz",
+          "x-checker-data": {
+            "type": "jetbrains",
+            "code": "IIU"
+          }
         }
       ]
     }


### PR DESCRIPTION
Moving at the end because the external checker need it to be the last checked URL to update the appdata