### PR TITLE
Add AppMenu to finish args

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -19,6 +19,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.keyring.SystemPrompter
+  - --talk-name=com.canonical.AppMenu.Registrar
 modules:
   - shared-modules/libsecret/libsecret.json
 


### PR DESCRIPTION
This pull request adds a new entry to the finish args to enable Global Menu widgets from kde and xfce to recognize the intellij's global menu and integrate them.

Image 1: Example without the new finish args
![Screenshot_20220530_153836](https://user-images.githubusercontent.com/51462138/171045893-02b9a548-150c-4c92-9bd4-23093bb9fd68.png)

Image 2: Example with the new finish args
![Screenshot_20220530_153808](https://user-images.githubusercontent.com/51462138/171045919-6b11e195-05cb-434e-b951-3ffb83968a82.png)

