### PR TITLE
Add --recurse-submodules opt to git clone

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -13,7 +13,7 @@ Assuming `flatpak`, `flatpak-builder`, and `git` are installed, then execute the
 
 [source,shell]
 ----
-$ git clone https://github.com/flathub/com.jetbrains.IntelliJ-IDEA-Ultimate.git
+$ git clone --recurse-submodules https://github.com/flathub/com.jetbrains.IntelliJ-IDEA-Ultimate.git
 $ cd com.jetbrains.IntelliJ-IDEA-Ultimate/
 $ flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
 $ flatpak-builder build --force-clean --install-deps-from=flathub --install --user com.jetbrains.IntelliJ-IDEA-Ultimate.yaml


### PR DESCRIPTION
Without the `--recurse-submodules` the build instructions fails with:

```
$ flatpak-builder build --force-clean --install-deps-from=flathub --install --user com.jetbrains.IntelliJ-IDEA-Ultimate.yaml

(flatpak-builder:405036): flatpak-builder-ERROR **: 13:30:28.090: Failed to load included manifest (/home/msitarz/TEMP/com.jetbrains.IntelliJ-IDEA-Ultimate/shared-modules/libsecret/libsecret.json): Failed to open file “/home/msitarz/TEMP/com.jetbrains.IntelliJ-IDEA-Ultimate/shared-modules/libsecret/libsecret.json”: No such file or directory
Trace/breakpoint trap (core dumped)
[Exit 133 TRAP]
```