### PR TITLE
Add rsync for remote development

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -23,6 +23,26 @@ finish-args:
 modules:
   - shared-modules/libsecret/libsecret.json
 
+  - name: rsync
+    cleanup:
+      - /share/man
+    config-opts:
+      - --prefix=${FLATPAK_DEST}
+      - --with-included-popt
+      - --with-included-zlib
+      - --disable-debug
+      - --disable-md2man
+      - --disable-xxhash
+    sources:
+      - type: archive
+        url: https://download.samba.org/pub/rsync/src/rsync-3.2.7.tar.gz
+        sha256: 4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb
+        x-checker-data:
+          type: anitya
+          project-id: 4217
+          stable-only: true
+          url-template: https://download.samba.org/pub/rsync/src/rsync-$version.tar.gz
+
   - name: gcr
     cleanup:
       - /include


### PR DESCRIPTION
Similar to https://github.com/flathub/com.jetbrains.GoLand/pull/42 and https://github.com/flathub/com.jetbrains.CLion/pull/38.

`rsync` is the preferred tool to enable file synchronization for remote development, and it also cannot be explicitly disabled for some remote mapping kinds. With this addition even those seems to work as intended, `Tools -> Resync with Remote Hosts` needs to be invoked once to trigger synchronization.

The community edition does not have the remote development feature, and thus does not need this addition.