### PR TITLE
add jetbrains-flatpak-wrapper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "shared-modules"]
 	path = shared-modules
 	url = https://github.com/flathub/shared-modules.git
+[submodule "jetbrains-flatpak-wrapper"]
+	path = jetbrains-flatpak-wrapper
+	url = https://github.com/Lctrs/jetbrains-flatpak-wrapper.git

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -131,3 +131,13 @@ modules:
         sha256: e80013a85454435dd1ebb80254c0aa0ed5ebaac825f93d82c801e7dd55c75d50
         size: 2201
         url: https://resources.jetbrains.com/storage/products/company/brand/logos/IntelliJ_IDEA_icon.svg
+
+  - name: wrapper
+    buildsystem: meson
+    config-opts:
+      - -Deditor_binary=/app/extra/idea-IU/bin/idea.sh # Path to the editor executable
+      - -Dprogram_name=idea # Install wrapper under this name
+      - -Deditor_title=Intellij IDEA Ultimate # Human-readable editor name
+    sources:
+      - type: dir
+        path: jetbrains-flatpak-wrapper


### PR DESCRIPTION
This wrapper sets a development environment for the IDE. Also used in [com.jetbrains.WebStorm](https://github.com/flathub/com.jetbrains.WebStorm). Makes it easier to work with node.js in the flatpak, while also supporting other runtimes.

- Adds FLATPAK_ENABLE_SDK_EXT runtimes to sandbox PATH (requested in issue #117 )
- Displays README on first launch
- Displays a notice after SDK update
- Isolate npm/pip/cargo/etc packages from host environment (allows persistence for global packages)