### PR TITLE
add git-lfs

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -150,7 +150,7 @@ modules:
       url: https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-amd64-v3.3.0.tar.gz
       sha256: 6a4e6bd7d06d5c024bc70c8ee8c9da143ffc37d2646e252a17a6126d30cdebc1
       x-checker-data:
-          project-id: 4217
+          project-id: 11551
           stable-only: true
           type: anitya
           url-template: https://github.com/git-lfs/git-lfs/releases/download/$version/git-lfs-linux-amd64-$version.tar.gz

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -153,7 +153,7 @@ modules:
           project-id: 11551
           stable-only: true
           type: anitya
-          url-template: https://github.com/git-lfs/git-lfs/releases/download/$version/git-lfs-linux-amd64-$version.tar.gz
+          url-template: https://github.com/git-lfs/git-lfs/releases/download/v$version/git-lfs-linux-amd64-v$version.tar.gz
 
 runtime: org.freedesktop.Sdk
 runtime-version: '22.08'

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -150,10 +150,10 @@ modules:
       url: https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-amd64-v3.3.0.tar.gz
       sha256: 6a4e6bd7d06d5c024bc70c8ee8c9da143ffc37d2646e252a17a6126d30cdebc1
       x-checker-data:
-        type: json
-        url: https://api.github.com/repos/git-lfs/git-lfs/releases/latest
-        version-query: "tag_name | sub(\"^[vV]\";\"\")"
-        url-query: ".assets[] | select(.label==\"Source\") | .browser_download_url"
+          project-id: 4217
+          stable-only: true
+          type: anitya
+          url-template: https://github.com/git-lfs/git-lfs/releases/download/$version/git-lfs-linux-amd64-$version.tar.gz
 
 runtime: org.freedesktop.Sdk
 runtime-version: '22.08'

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -141,6 +141,19 @@ modules:
         path: com.jetbrains.IntelliJ-IDEA-Ultimate.metainfo.xml
       - type: file
         path: idea.properties
+  - name: git-lfs
+    buildsystem: simple
+    build-commands:
+      - PREFIX=${FLATPAK_DEST} ./install.sh
+    sources:
+    - type: archive
+      url: https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-amd64-v3.3.0.tar.gz
+      sha256: 6a4e6bd7d06d5c024bc70c8ee8c9da143ffc37d2646e252a17a6126d30cdebc1
+      x-checker-data:
+        type: json
+        url: https://api.github.com/repos/git-lfs/git-lfs/releases/latest
+        version-query: tag_name | sub(\"^[vV]\";\"\")
+        url-query: .assets[] | select(.label==\"Source\") | .browser_download_url
 
 runtime: org.freedesktop.Sdk
 runtime-version: '22.08'

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -150,10 +150,10 @@ modules:
       url: https://github.com/git-lfs/git-lfs/releases/download/v3.3.0/git-lfs-linux-amd64-v3.3.0.tar.gz
       sha256: 6a4e6bd7d06d5c024bc70c8ee8c9da143ffc37d2646e252a17a6126d30cdebc1
       x-checker-data:
-          project-id: 11551
-          stable-only: true
-          type: anitya
-          url-template: https://github.com/git-lfs/git-lfs/releases/download/v$version/git-lfs-linux-amd64-v$version.tar.gz
+        project-id: 11551
+        stable-only: true
+        type: anitya
+        url-template: https://github.com/git-lfs/git-lfs/releases/download/v$version/git-lfs-linux-amd64-v$version.tar.gz
 
 runtime: org.freedesktop.Sdk
 runtime-version: '22.08'

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -152,8 +152,8 @@ modules:
       x-checker-data:
         type: json
         url: https://api.github.com/repos/git-lfs/git-lfs/releases/latest
-        version-query: tag_name | sub(\"^[vV]\";\"\")
-        url-query: .assets[] | select(.label==\"Source\") | .browser_download_url
+        version-query: "tag_name | sub(\"^[vV]\";\"\")"
+        url-query: ".assets[] | select(.label==\"Source\") | .browser_download_url"
 
 runtime: org.freedesktop.Sdk
 runtime-version: '22.08'


### PR DESCRIPTION
Because much of my projects use git-lfs and maybe from some others too, it would be very nice to have it in the Flathub flatpak.

Works on local machine perfectly.

If there is another (easy) option to access git-lfs inside IntelliJ you can just tell me about that, I'm new to Flatpaks.

Woops sorry for the Spam