### PR TITLE
fix: make GPG commit signing work again, remove dependencies from 74152a7

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -9,7 +9,7 @@ finish-args:
   - --filesystem=host
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/docker
-  - --filesystem=xdg-run/gnupg:ro # This is required instead of --socket=gpg-agent for the pinentry dialog to work
+  - --filesystem=xdg-run/gnupg:ro
   - --filesystem=xdg-run/keyring
   - --filesystem=xdg-run/pipewire-0:ro
   - --filesystem=xdg-run/podman
@@ -17,9 +17,6 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --socket=ssh-auth
-# https://github.com/flatpak/flatpak/issues/5863 breaks pinentry (GPG commit signing),
-# disable Wayland socket as a workaround since JetBrains IDEs aren't Wayland-native yet
-#  - --socket=wayland
   - --socket=x11
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.Flatpak

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -9,7 +9,7 @@ finish-args:
   - --filesystem=host
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/docker
-  - --filesystem=xdg-run/gnupg:ro
+  - --filesystem=xdg-run/gnupg:ro # This is required instead of --socket=gpg-agent for the pinentry dialog to work
   - --filesystem=xdg-run/keyring
   - --filesystem=xdg-run/pipewire-0:ro
   - --filesystem=xdg-run/podman
@@ -17,42 +17,18 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --socket=ssh-auth
-  - --socket=wayland
+# https://github.com/flatpak/flatpak/issues/5863 breaks pinentry (GPG commit signing),
+# disable Wayland socket as a workaround since JetBrains IDEs aren't Wayland-native yet
+#  - --socket=wayland
   - --socket=x11
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.secrets
-  - --talk-name=org.gnome.keyring.SystemPrompter
 
 modules:
   # -----------------------------------------------------------------------------------------------
   #   D E P E N D E N C I E S
   # -----------------------------------------------------------------------------------------------
-
-  - name: gcr
-    cleanup:
-      - /include
-      - /lib/debug
-      - /lib/girepository-1.0
-      - /lib/pkgconfig
-      - /man
-      - /share/gir-1.0
-      - /share/gtk-doc
-      - /share/doc
-      - /share/man
-      - /share/pkgconfig
-      - '*.a'
-      - '*.la'
-    config-opts:
-      - --disable-schemas-compile
-      - --disable-static
-      - --disable-update-mime
-      - --disable-vala
-      - --enable-valgrind=no
-    sources:
-      - type: archive
-        sha256: 29df50974a90987af694c0fb8926a6b366e68cacd8abd813817cfe1eb5d54524
-        url: https://download.gnome.org/sources/gcr/3.34/gcr-3.34.0.tar.xz
 
   - name: git-lfs
     build-commands:
@@ -92,36 +68,6 @@ modules:
         url: https://github.com/Lctrs/jetbrains-flatpak-wrapper.git
 
   - shared-modules/libsecret/libsecret.json
-
-  - name: openssh
-    build-commands:
-      - ln --symbolic /usr/bin/ssh /app/bin/ssh
-    buildsystem: simple
-
-  - name: pinentry
-    cleanup:
-      - /include
-      - /lib/debug
-      - /share/info
-      - '*.a'
-      - '*.la'
-    config-opts:
-      - --disable-fallback-curses
-      - --disable-ncurses
-      - --disable-pinentry-curses
-      - --disable-pinentry-emacs
-      - --disable-pinentry-fltk
-      - --disable-pinentry-gtk2
-      - --disable-pinentry-qt5
-      - --disable-pinentry-tqt
-      - --disable-pinentry-tty
-      - --enable-libsecret=no
-      - --enable-pinentry-gnome3
-      - --without-libcap
-    sources:
-      - type: archive
-        sha256: cd12a064013ed18e2ee8475e669b9f58db1b225a0144debdb85a68cecddba57f
-        url: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.1.tar.bz2
 
   - name: rsync
     cleanup:


### PR DESCRIPTION
After migrating to a fresh Fedora Kinoite 40 system, I noticed that creating signed commits from the IDE's dialog stopped working. Lots of troubleshooting revealed that the issue was a combination of a quirk with `gpg-agent` socket behavior and a contemporary Flatpak bug. This PR fixes the issue and removes some unnecessary dependencies in the process.

## Issue

Upon creating a signed commit, the `pinentry` dialog to unlock the signing key never appears, and in the error notification GnuPG complains

```
gpg: signing failed: No pinentry
```

GnuPG is hard-coded to invoke `/usr/bin/pinentry` for security reasons (PATH overrides could enable keyloggers), so `/app/bin/pinentry` and its dependencies inside the Flatpak are never used:

```
bash-5.2$ ls /app/bin/pinentry # Inside the Flatpak
/app/bin/pinentry
bash-5.2$ gpgconf 
gpg:OpenPGP:/usr/bin/gpg
gpgsm:S/MIME:/usr/bin/gpgsm
keyboxd:Public Keys:/usr/libexec/keyboxd
gpg-agent:Private Keys:/usr/bin/gpg-agent
scdaemon:Smartcards:/usr/libexec/scdaemon
dirmngr:Network:/usr/bin/dirmngr
pinentry:Passphrase Entry:/usr/bin/pinentry # <- /app/bin/pinentry will never be invoked
```

Instead, the app is [supposed to call the gpg-agent through the socket](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1621#note_1839037923), which then invokes `/usr/bin/pinentry` on the host without leaking the password input inside the Flatpak app.

This used to work on my system, but recently broke due to [a separate Flatpak bug with `WAYLAND_DISPLAY` handling](https://github.com/flatpak/flatpak/issues/5863). The easy fix is thus to simply disable passing of the Wayland socket to the Flatpak, which should be OK since the JetBrains IDEs do not yet support Wayland ([at least properly](https://blog.jetbrains.com/platform/2024/07/wayland-support-preview-in-2024-2/)). Now I had a working `pinentry` dialog again.

## Further investigation

In light of the seemingly random issues with `pinentry` highlighted in https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1621#note_1839037923, I investigated a bit further. Through trial-and-error I discovered that `pinentry` support breaks if the Flatpak is configured with `--socket=gpg-agent`, and starts working again if `--filesystem=xdg-run/gnupg:ro` is used instead. No idea why, but the latter also exposes `/run/user/1000/gnupg/S.scdaemon` in addition to `/run/user/1000/gnupg/S.gpg-agent` which might affect things. Regardless, it works with the `--filesystem` way it's already configured here.

## Unnecessary dependencies

Since `/app/bin/pinentry` is never invoked, I decided to revert the extra dependencies from 74152a7 to shrink the attack surface. I'm pretty sure no other component in the IDE relies on them, but please let me know if I'm wrong.

Fixes https://github.com/flathub/com.jetbrains.IntelliJ-IDEA-Ultimate/issues/134 (and likely https://github.com/flathub/com.jetbrains.IntelliJ-IDEA-Community/issues/122 if ported to the community version)