### PR TITLE
Enable Wayland support

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -15,10 +15,10 @@ finish-args:
   - --filesystem=xdg-run/podman
   - --share=ipc
   - --share=network
-  - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --socket=wayland
+  - --socket=x11
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.secrets

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -15,10 +15,10 @@ finish-args:
   - --filesystem=xdg-run/podman
   - --share=ipc
   - --share=network
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --socket=wayland
-  - --socket=x11
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.secrets

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.yaml
@@ -17,6 +17,7 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --socket=ssh-auth
+  - --socket=wayland
   - --socket=x11
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.Flatpak


### PR DESCRIPTION
JetBrains announced that, starting with the 2024.2, IntelliJ-based IDEs will offer preliminary support for the Wayland display server protocol on Linux, including Windows Subsystem for Linux a.k.a. [WSLg](https://github.com/microsoft/wslg).

This will configure support for wayland permission, and people should be able to [enable it](https://blog.jetbrains.com/platform/2024/07/wayland-support-preview-in-2024-2/) by using the `-Dawt.toolkit.name=WLToolkit` option.

Resolves #196