### PR TITLE
Add Flatpak talk to allow flatpak-spawn to work

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.json
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.json
@@ -13,6 +13,7 @@
     "--device=all",
     "--filesystem=home",
     "--env=JAVA_HOME=/app/extra/idea-IU/jbr",
+    "--talk-name=org.freedesktop.Flatpak",
     "--talk-name=org.freedesktop.Notifications",
     "--talk-name=org.freedesktop.secrets",
     "--talk-name=com.canonical.AppMenu.Registrar",


### PR DESCRIPTION
## Changes

 - Allow flatpak-spawn to work by adding Flatpak talk-name, as [first_run.txt](https://github.com/flathub/com.jetbrains.IntelliJ-IDEA-Ultimate/blob/4ebfcd1b304f826f0b7269e6357c8056820b7dfa/first_run.txt#L15) suggest

Fixes #227