### PR TITLE
fix: "open with" in file manager not listing Intellij as candidate

### DIFF
--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.desktop
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Categories=Development;IDE;
-Exec=idea-wrapper
+Exec=idea-wrapper %F
 GenericName=Capable and Ergonomic IDE for the Java Virtual Machine
 Icon=com.jetbrains.IntelliJ-IDEA-Ultimate
 Keywords=development;idea;ide;intellij;java;

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.desktop
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.desktop
@@ -4,6 +4,7 @@ Exec=idea-wrapper %F
 GenericName=Capable and Ergonomic IDE for the Java Virtual Machine
 Icon=com.jetbrains.IntelliJ-IDEA-Ultimate
 Keywords=development;idea;ide;intellij;java;
+MimeType=text/plain;inode/directory;
 Name=IntelliJ IDEA
 StartupNotify=true
 StartupWMClass=jetbrains-idea


### PR DESCRIPTION
Currently, some file managers such as nautilus do not show Intellij when triggering the `open with` dialog:
<img width="435" height="583" alt="image" src="https://github.com/user-attachments/assets/4a03287a-409c-41b6-b8c6-4b0a54b96b3d" />

Adding `%F` makes nautilus display it as an option:
<img width="435" height="583" alt="image" src="https://github.com/user-attachments/assets/278d515d-5737-4b45-bce9-43a1ab467e28" />