### PR TITLE
add xrandr and add xwayland gui app note

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,17 @@ $ ls /app/bin (bundled with this flatpak)
 ```
 
 ## Running GUI app from IDE
-By default, java uses X11 but not exist inside Flatpak there is only Wayland.
+By default, Java uses X11.
+If your session is running under Wayland.
 You need to switch to Wayland toolkit for your app.
 Go to `Edit Configuration`, `Modify options` and enable `Add VM Options`.
 On the new box named `VM Options` add:
 
 `-Dawt.toolkit.name=WLToolkit`
+
+Or use X11 via XWayland if enabled by your compositor:
+
+`flatpak override --user com.jetbrains.IntelliJ-IDEA-Ultimate --socket=x11`
 
 ## Flatpak extensions
 To get support for additional languages, you have to install SDK extensions, e.g.

--- a/com.jetbrains.IntelliJ-IDEA-Ultimate.json
+++ b/com.jetbrains.IntelliJ-IDEA-Ultimate.json
@@ -104,6 +104,23 @@
             ]
         },
         {
+            "name": "xrandr",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.4.tar.xz",
+                    "sha256": "2cafccb2aaf2491a4068676117a0d4f90ab307724b96fffc54cd1da953779400",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 385141,
+                        "stable-only": true,
+                        "url-template": "https://xorg.freedesktop.org/archive/individual/app/xrandr-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
             "name": "ide-flatpak-wrapper",
             "buildsystem": "meson",
             "config-opts": [


### PR DESCRIPTION
This change fixes an issue encountered when developing applications based on LWJGL 2.

LWJGL 2 requires `xrandr` on Linux for display detection and initialization. Without this dependency, LWJGL 2 based projects may fail to launch during development and debugging.

This change adds the required `xrandr` dependency and improves the documentation for running GUI applications under Wayland environments.

With this fix, LWJGL 2 based development environments can run correctly in Flatpak, allowing projects such as older Minecraft modding environments to be debugged normally.

Related discussion:
http://forum.lwjgl.org/index.php?topic=5742.0